### PR TITLE
Abort if user escapes input box

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,9 +52,11 @@ export function activate(context: vscode.ExtensionContext) {
         pass = config.keypass;
 
         if (pass == "") {
-          await vscode.window.showInputBox({ prompt: "Enter the ansible-vault keypass: " }).then((val) => {
-            pass = val;
-          })
+          pass = await vscode.window.showInputBox({ prompt: "Enter the ansible-vault keypass: " })
+
+          if (typeof pass === 'undefined') {
+            return
+          }
         }
 
         keypath = tmp.tmpNameSync();


### PR DESCRIPTION
When the user presses escape while the input box for typing the vault keypass the execution continues. This makes sure the script will not continue by checking if the returned value is `undefined`.

[API Documentation](https://code.visualstudio.com/api/references/vscode-api) states:
> The returned value will be undefined if the input box was canceled (e.g. pressing ESC).